### PR TITLE
Add min sdk requirement on AndroidManifest and more descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently only fetching the following 5 fields:
 
 For iOS it is not possible to extract the call log programmatically. Apple officially does not expose any public API to access the call log. So all the method will return null on iOS.
 
+**Warning:** SDK Version: This plugin needs minimum SDK of 21. getPhoneLogs() method needs minimum SDK of 23.
+
 ## Getting Started
 
 Make sure you add the permission below to your Android Manifest Permission:

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.jiajiabingcheng.phonelog">
+    <uses-sdk android:minSdkVersion="21" />
     <uses-permission android:name="android.permission.READ_CALL_LOG"/>
 </manifest>


### PR DESCRIPTION
This plugin supports a minimum SDK version of 21, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it.