### PR TITLE
Include min sdk version requirement

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.jiajiabingcheng.phonelog">
+    <uses-sdk android:minSdkVersion="16" />
     <uses-permission android:name="android.permission.READ_CALL_LOG"/>
 </manifest>


### PR DESCRIPTION
Right now flutter supports a minimum SDK version of 16 and all plugins should be able to match it, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it.